### PR TITLE
api: fix idle-timeout reader leak and share HTTP transport

### DIFF
--- a/internal/batchexecute/batchexecute.go
+++ b/internal/batchexecute/batchexecute.go
@@ -723,25 +723,32 @@ func cloneHeader(h http.Header) http.Header {
 	return out
 }
 
-// NewIPv4HTTPClient creates an HTTP client that prefers IPv4 connections.
-// This works around environments where IPv6 sockets are broken (e.g., sandboxed terminals).
-// The key is resolving DNS to IPv4 addresses, not just dialing with "tcp4".
-func NewIPv4HTTPClient() *http.Client {
+// sharedIPv4Transport is a process-wide HTTP transport with an IPv4-preferring
+// dialer. Building a fresh Transport for every request (the previous pattern)
+// leaked idle TCP sockets: each Transport keeps its own pool alive for
+// IdleConnTimeout (90s) after the wrapping *http.Client goes out of scope, and
+// none of the call sites invoke CloseIdleConnections. Under a moderate burst
+// of API calls — especially the streaming chat path — fds accumulated until
+// the process could no longer dial, surfacing as "the first N calls work and
+// then everything hangs".
+//
+// Sharing the Transport also makes MaxIdleConnsPerHost meaningful: without
+// this it defaults to 2 and most idle slots in MaxIdleConns were unreachable
+// since every call has its own Transport.
+var sharedIPv4Transport = func() *http.Transport {
 	resolver := &net.Resolver{}
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
-	transport := &http.Transport{
+	return &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			// Resolve hostname to IPv4 addresses and try those first.
 			host, port, err := net.SplitHostPort(addr)
 			if err != nil {
 				return dialer.DialContext(ctx, network, addr)
 			}
 			ips, err := resolver.LookupIPAddr(ctx, host)
 			if err == nil {
-				// Try IPv4 addresses first
 				for _, ip := range ips {
 					if ip.IP.To4() != nil {
 						conn, err := dialer.DialContext(ctx, "tcp4", net.JoinHostPort(ip.IP.String(), port))
@@ -751,14 +758,21 @@ func NewIPv4HTTPClient() *http.Client {
 					}
 				}
 			}
-			// Fall back to default resolution
 			return dialer.DialContext(ctx, network, addr)
 		},
 		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 32,
 		IdleConnTimeout:     90 * time.Second,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
-	return &http.Client{Transport: transport}
+}()
+
+// NewIPv4HTTPClient returns an HTTP client that prefers IPv4 connections.
+// This works around environments where IPv6 sockets are broken (e.g., sandboxed
+// terminals). All clients share a single Transport so connections are pooled
+// across requests.
+func NewIPv4HTTPClient() *http.Client {
+	return &http.Client{Transport: sharedIPv4Transport}
 }
 
 // ReqIDGenerator generates sequential request IDs

--- a/internal/notebooklm/api/client.go
+++ b/internal/notebooklm/api/client.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -42,48 +43,66 @@ func httpClientWithTimeout(timeout time.Duration) *http.Client {
 
 // idleTimeoutReader wraps a reader and enforces a per-read idle timeout.
 // Unlike http.Client.Timeout which limits the entire request/response,
-// this resets the deadline on each successful read — suitable for
+// this resets the deadline at the start of each Read — suitable for
 // long-running streaming responses where data arrives in chunks.
+//
+// When the idle timer fires, the underlying reader is closed, which
+// unblocks any in-flight Read on the same goroutine with an error.
+// This avoids the goroutine-per-Read pattern, which leaked goroutines
+// and produced concurrent reads on the same body when the timer
+// fired spuriously (a common consequence of time.Timer.Reset being
+// called without first stopping and draining the timer channel).
 type idleTimeoutReader struct {
 	r       io.ReadCloser
 	timeout time.Duration
 	timer   *time.Timer
-	done    chan struct{}
+
+	mu       sync.Mutex
+	timedOut bool
+	closed   bool
 }
 
 func newIdleTimeoutReader(r io.ReadCloser, timeout time.Duration) *idleTimeoutReader {
-	return &idleTimeoutReader{
+	itr := &idleTimeoutReader{
 		r:       r,
 		timeout: timeout,
-		timer:   time.NewTimer(timeout),
-		done:    make(chan struct{}),
 	}
+	itr.timer = time.AfterFunc(timeout, itr.onTimeout)
+	return itr
+}
+
+func (r *idleTimeoutReader) onTimeout() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return
+	}
+	r.timedOut = true
+	r.closed = true
+	_ = r.r.Close()
 }
 
 func (r *idleTimeoutReader) Read(p []byte) (int, error) {
-	// Reset the idle timer before each read.
 	r.timer.Reset(r.timeout)
-	type result struct {
-		n   int
-		err error
+	n, err := r.r.Read(p)
+
+	r.mu.Lock()
+	timedOut := r.timedOut
+	r.mu.Unlock()
+
+	if timedOut {
+		return n, fmt.Errorf("idle timeout: no data received for %s", r.timeout)
 	}
-	ch := make(chan result, 1)
-	go func() {
-		n, err := r.r.Read(p)
-		ch <- result{n, err}
-	}()
-	select {
-	case res := <-ch:
-		return res.n, res.err
-	case <-r.timer.C:
-		return 0, fmt.Errorf("idle timeout: no data received for %s", r.timeout)
-	case <-r.done:
-		return 0, fmt.Errorf("reader closed")
-	}
+	return n, err
 }
 
 func (r *idleTimeoutReader) Close() error {
-	close(r.done)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil
+	}
+	r.closed = true
 	r.timer.Stop()
 	return r.r.Close()
 }

--- a/internal/notebooklm/api/idle_timeout_reader_test.go
+++ b/internal/notebooklm/api/idle_timeout_reader_test.go
@@ -1,0 +1,200 @@
+package api
+
+import (
+	"errors"
+	"io"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// blockingReader returns one chunk per Read call, blocking until either
+// the chunk is delivered, the reader is Closed, or the test signals via
+// release. It tracks concurrent Read invocations so the test can assert
+// that no two Reads ever run against the same underlying body.
+type blockingReader struct {
+	chunks  chan []byte
+	closed  chan struct{}
+	inFlight int32
+	maxConcurrent int32
+}
+
+func newBlockingReader() *blockingReader {
+	return &blockingReader{
+		chunks: make(chan []byte, 16),
+		closed: make(chan struct{}),
+	}
+}
+
+func (b *blockingReader) Read(p []byte) (int, error) {
+	c := atomic.AddInt32(&b.inFlight, 1)
+	defer atomic.AddInt32(&b.inFlight, -1)
+	for {
+		m := atomic.LoadInt32(&b.maxConcurrent)
+		if c <= m || atomic.CompareAndSwapInt32(&b.maxConcurrent, m, c) {
+			break
+		}
+	}
+	select {
+	case chunk, ok := <-b.chunks:
+		if !ok {
+			return 0, io.EOF
+		}
+		n := copy(p, chunk)
+		return n, nil
+	case <-b.closed:
+		return 0, io.ErrClosedPipe
+	}
+}
+
+func (b *blockingReader) Close() error {
+	select {
+	case <-b.closed:
+		// already closed
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
+func (b *blockingReader) feed(data string) { b.chunks <- []byte(data) }
+
+// TestIdleTimeoutReader_ResetExtendsDeadline verifies that data arriving
+// before the idle timeout resets the deadline and does not produce a
+// spurious timeout error on subsequent reads. The previous implementation
+// called timer.Reset without first stopping and draining the channel,
+// causing a stale tick to fire the timeout case immediately on the next
+// Read even when fresh data was arriving.
+func TestIdleTimeoutReader_ResetExtendsDeadline(t *testing.T) {
+	br := newBlockingReader()
+	r := newIdleTimeoutReader(br, 100*time.Millisecond)
+	defer r.Close()
+
+	// Feed several chunks at intervals shorter than the timeout; the
+	// reader should successfully consume all of them.
+	go func() {
+		for i := 0; i < 5; i++ {
+			time.Sleep(40 * time.Millisecond)
+			br.feed("chunk")
+		}
+		// Allow the consumer's final Read to return before closing.
+		time.Sleep(40 * time.Millisecond)
+		br.Close()
+	}()
+
+	buf := make([]byte, 64)
+	got := 0
+	for {
+		n, err := r.Read(buf)
+		got += n
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
+				break
+			}
+			t.Fatalf("unexpected error after %d bytes: %v", got, err)
+		}
+	}
+	if got != 5*len("chunk") {
+		t.Fatalf("got %d bytes, want %d", got, 5*len("chunk"))
+	}
+}
+
+// TestIdleTimeoutReader_FiresOnIdle verifies that the idle timeout
+// triggers when no data arrives and that the in-flight Read unblocks
+// promptly (rather than leaving an orphan goroutine, which was the
+// previous implementation's failure mode).
+func TestIdleTimeoutReader_FiresOnIdle(t *testing.T) {
+	br := newBlockingReader()
+	r := newIdleTimeoutReader(br, 50*time.Millisecond)
+	defer r.Close()
+
+	gBefore := runtime.NumGoroutine()
+
+	buf := make([]byte, 64)
+	start := time.Now()
+	_, err := r.Read(buf)
+	elapsed := time.Since(start)
+
+	if err == nil || !strings.Contains(err.Error(), "idle timeout") {
+		t.Fatalf("want idle timeout error, got %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("Read took %v, expected ~50ms", elapsed)
+	}
+
+	// Give the runtime a moment to reap any goroutines that the Read
+	// might have spawned. The new implementation spawns none; the old
+	// one orphaned one goroutine per Read call.
+	time.Sleep(50 * time.Millisecond)
+	gAfter := runtime.NumGoroutine()
+	if gAfter > gBefore+1 {
+		t.Fatalf("goroutine leak: before=%d after=%d", gBefore, gAfter)
+	}
+}
+
+// TestIdleTimeoutReader_NoConcurrentBodyReads exercises many Read calls
+// against a reader whose chunks arrive at intervals close to the idle
+// timeout. The original code spawned a goroutine per Read; if the timer
+// fired spuriously the parent returned but the orphan goroutine kept
+// reading the body, producing two concurrent Reads on the same body.
+// Here we assert the underlying body never sees more than one in-flight
+// Read at any time.
+func TestIdleTimeoutReader_NoConcurrentBodyReads(t *testing.T) {
+	br := newBlockingReader()
+	r := newIdleTimeoutReader(br, 30*time.Millisecond)
+	defer r.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 20; i++ {
+			time.Sleep(15 * time.Millisecond)
+			br.feed("x")
+		}
+		br.Close()
+	}()
+
+	buf := make([]byte, 8)
+	for {
+		_, err := r.Read(buf)
+		if err != nil {
+			break
+		}
+	}
+	<-done
+
+	if max := atomic.LoadInt32(&br.maxConcurrent); max > 1 {
+		t.Fatalf("body saw %d concurrent reads; want 1", max)
+	}
+}
+
+// TestIdleTimeoutReader_CloseUnblocks verifies that calling Close on
+// the wrapper unblocks an in-flight Read by closing the underlying
+// body.
+func TestIdleTimeoutReader_CloseUnblocks(t *testing.T) {
+	br := newBlockingReader()
+	r := newIdleTimeoutReader(br, time.Hour)
+
+	errCh := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 8)
+		_, err := r.Read(buf)
+		errCh <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatalf("expected error after Close")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Read did not unblock after Close")
+	}
+}


### PR DESCRIPTION
Two related defects caused chat (and other streaming) calls to hang after a handful of MCP requests:

1. idleTimeoutReader spawned a goroutine per Read and never cancelled it. When the idle timer fired the parent returned but the orphan kept blocking on the underlying body, holding the caller's buffer. The next Read on the same body produced two concurrent readers, corrupting the stream. Replace the goroutine+select dance with a time.AfterFunc that closes the body on idle — the in-flight Read unblocks naturally and no goroutine is leaked. Guard the close path with a mutex so Close and the timer callback can't both close the underlying reader.

2. httpClientWithTimeout built a brand-new http.Transport on every call. Each Transport kept its own idle connection pool alive for IdleConnTimeout (90s) after the wrapping client went out of scope and CloseIdleConnections was never called, so TCP sockets piled up under bursty MCP traffic until the process could no longer dial. Move the Transport to a package-level singleton and set MaxIdleConnsPerHost (the default of 2 made most of the existing MaxIdleConns=100 budget unreachable).

Add tests covering reset-extends-deadline, idle firing, no-concurrent- body-reads, and Close unblocking an in-flight Read.