### PR TITLE
all: fix vet lock-copy and gofmt formatting

### DIFF
--- a/cmd/nlm/betool_test.go
+++ b/cmd/nlm/betool_test.go
@@ -543,9 +543,9 @@ func TestBetoolProtoErrors(t *testing.T) {
 // list wrapper would drop these below lossless and fail here.
 func TestBetoolProtoRequestFixtures(t *testing.T) {
 	cases := []struct {
-		file    string // fixture basename
+		file     string // fixture basename
 		selector string // --rpc-id value (rpc_id, or method name to disambiguate)
-		typ     string
+		typ      string
 	}{
 		{"wXbhsf", "wXbhsf", "notebooklm.v1alpha1.ListRecentlyViewedProjectsRequest"},
 		{"LQhfEb", "LQhfEb", "notebooklm.v1alpha1.UpdateProjectUserStateRequest"},

--- a/cmd/nlm/label_list_test.go
+++ b/cmd/nlm/label_list_test.go
@@ -25,10 +25,10 @@ func TestRenderLabelList_TableOutput(t *testing.T) {
 		wantStat []string
 	}{
 		{
-			name:    "tty with rows",
-			labels:  labelListFixture,
-			tty:     true,
-			wantOut: []string{"LABEL ID\tNAME\tSOURCES", "lbl-1\tTesting\t2", "lbl-2\tRPC and Networking\t1", "lbl-3\tEmpty Label\t0"},
+			name:     "tty with rows",
+			labels:   labelListFixture,
+			tty:      true,
+			wantOut:  []string{"LABEL ID\tNAME\tSOURCES", "lbl-1\tTesting\t2", "lbl-2\tRPC and Networking\t1", "lbl-3\tEmpty Label\t0"},
 			wantStat: []string{"Total labels: 3"},
 		},
 		{

--- a/cmd/nlm/source_match_test.go
+++ b/cmd/nlm/source_match_test.go
@@ -24,12 +24,12 @@ func TestResolveSelectorIDs(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		opts      selectorOptions
-		flagIDs   []string
-		labelIDs  []string
-		want      []string
-		wantErr   string
+		name               string
+		opts               selectorOptions
+		flagIDs            []string
+		labelIDs           []string
+		want               []string
+		wantErr            string
 		wantStatusContains []string
 	}{
 		{
@@ -44,21 +44,21 @@ func TestResolveSelectorIDs(t *testing.T) {
 			want:    []string{"src-spec-1", "src-impl-1"},
 		},
 		{
-			name: "source-match only",
-			opts: selectorOptions{SourceMatch: "^spec/"},
-			want: []string{"src-spec-1", "src-spec-2", "src-draft-1"},
+			name:               "source-match only",
+			opts:               selectorOptions{SourceMatch: "^spec/"},
+			want:               []string{"src-spec-1", "src-spec-2", "src-draft-1"},
 			wantStatusContains: []string{"--source-match", "3 source(s)"},
 		},
 		{
-			name: "source-match no hits errors and lists",
-			opts: selectorOptions{SourceMatch: "^never/"},
-			wantErr: "--source-match matched no sources",
+			name:               "source-match no hits errors and lists",
+			opts:               selectorOptions{SourceMatch: "^never/"},
+			wantErr:            "--source-match matched no sources",
 			wantStatusContains: []string{"matched no sources", "spec/architecture"},
 		},
 		{
-			name: "source-exclude alone is all-minus",
-			opts: selectorOptions{SourceExclude: "draft"},
-			want: []string{"src-spec-1", "src-spec-2", "src-impl-1", "src-impl-2"},
+			name:               "source-exclude alone is all-minus",
+			opts:               selectorOptions{SourceExclude: "draft"},
+			want:               []string{"src-spec-1", "src-spec-2", "src-impl-1", "src-impl-2"},
 			wantStatusContains: []string{"--source-exclude"},
 		},
 		{
@@ -67,29 +67,29 @@ func TestResolveSelectorIDs(t *testing.T) {
 			want: []string{"src-spec-1", "src-spec-2"},
 		},
 		{
-			name: "exclude wins over include",
-			opts: selectorOptions{SourceIDs: "src-draft-1,src-spec-1", SourceExclude: "draft"},
+			name:    "exclude wins over include",
+			opts:    selectorOptions{SourceIDs: "src-draft-1,src-spec-1", SourceExclude: "draft"},
 			flagIDs: []string{"src-draft-1", "src-spec-1"},
-			want: []string{"src-spec-1"},
+			want:    []string{"src-spec-1"},
 		},
 		{
-			name: "label-match include OR semantics",
-			opts: selectorOptions{LabelMatch: "^Testing$"},
-			want: []string{"src-impl-1", "src-impl-2"},
+			name:               "label-match include OR semantics",
+			opts:               selectorOptions{LabelMatch: "^Testing$"},
+			want:               []string{"src-impl-1", "src-impl-2"},
 			wantStatusContains: []string{"label \"Testing\""},
 		},
 		{
-			name: "label-ids include unioned with label-match",
-			opts: selectorOptions{LabelMatch: "^Testing$", LabelIDs: "lbl-rpc"},
+			name:     "label-ids include unioned with label-match",
+			opts:     selectorOptions{LabelMatch: "^Testing$", LabelIDs: "lbl-rpc"},
 			labelIDs: []string{"lbl-rpc"},
 			// Order follows the labels slice (Testing first, then RPC); src-impl-1
 			// appears once via the dedup map even though both labels include it.
 			want: []string{"src-impl-1", "src-impl-2", "src-spec-2"},
 		},
 		{
-			name: "label-exclude removes tagged sources",
-			opts: selectorOptions{SourceMatch: "^impl/", LabelExclude: "^Testing$"},
-			want: nil,
+			name:    "label-exclude removes tagged sources",
+			opts:    selectorOptions{SourceMatch: "^impl/", LabelExclude: "^Testing$"},
+			want:    nil,
 			wantErr: "selectors resolved to empty set after exclusions",
 		},
 		{
@@ -98,9 +98,9 @@ func TestResolveSelectorIDs(t *testing.T) {
 			want: []string{"src-spec-1", "src-spec-2", "src-impl-1", "src-impl-2"},
 		},
 		{
-			name: "label include with no match errors",
-			opts: selectorOptions{LabelMatch: "^Nonexistent$"},
-			wantErr: "label selectors matched no labels",
+			name:               "label include with no match errors",
+			opts:               selectorOptions{LabelMatch: "^Nonexistent$"},
+			wantErr:            "label selectors matched no labels",
 			wantStatusContains: []string{"matched no labels", "Testing", "Draft"},
 		},
 		{
@@ -114,10 +114,10 @@ func TestResolveSelectorIDs(t *testing.T) {
 			wantErr: "--label-exclude: invalid regex",
 		},
 		{
-			name: "source-ids unioned with source-match",
-			opts: selectorOptions{SourceIDs: "src-impl-2", SourceMatch: "^spec/"},
+			name:    "source-ids unioned with source-match",
+			opts:    selectorOptions{SourceIDs: "src-impl-2", SourceMatch: "^spec/"},
 			flagIDs: []string{"src-impl-2"},
-			want: []string{"src-impl-2", "src-spec-1", "src-spec-2", "src-draft-1"},
+			want:    []string{"src-impl-2", "src-spec-1", "src-spec-2", "src-draft-1"},
 		},
 		{
 			name: "exclusions only with empty include list still returns all-minus",

--- a/gen/method/bulk_import_text_source_test.go
+++ b/gen/method/bulk_import_text_source_test.go
@@ -1,6 +1,5 @@
 package method
 
-
 import (
 	"encoding/json"
 	"testing"

--- a/gen/method/list_recently_viewed_projects_test.go
+++ b/gen/method/list_recently_viewed_projects_test.go
@@ -16,7 +16,7 @@ func TestListRecentlyViewedProjectsFullRequestKeepsLiveEncoder(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if req.GetProjectId() != "project-id" || req.GetContext() == nil || req.GetUnknown_5() != 0 {
-		t.Fatalf("full request did not retain its modeled fields: %+v", req)
+		t.Fatalf("full request did not retain its modeled fields: %+v", &req)
 	}
 	got, err := json.Marshal(EncodeListRecentlyViewedProjectsArgs(&req))
 	if err != nil {

--- a/internal/batchexecute/errors.go
+++ b/internal/batchexecute/errors.go
@@ -232,8 +232,8 @@ var errorCodeDictionary = map[int]ErrorCode{
 		Retryable:   false,
 	},
 	13: {
-		Code:        13,
-		Type:        ErrorTypeServerError,
+		Code: 13,
+		Type: ErrorTypeServerError,
 		// gRPC INTERNAL — the server hit an unexpected condition. For
 		// AddSourceFromText this most often means the payload tripped a
 		// content-shape limit (single chunk too large, embedded markers


### PR DESCRIPTION
Two hygiene fixes to bring `main` to a clean `go vet` + `gofmt` state.

- **vet lock-copy**: `gen/method/list_recently_viewed_projects_test.go` formatted a proto message by value in `t.Fatalf` (it embeds a `sync.Mutex` through `protoimpl.MessageState`). Format by pointer. This was the only `go vet ./...` finding on main.
- **gofmt**: `gofmt -w` five files that had drifted from canonical formatting (struct-field alignment) — `cmd/nlm` betool/label_list/source_match tests, `gen/method/bulk_import_text_source_test.go`, `internal/batchexecute/errors.go`.

No behavior change. `go build`, `go vet`, `go test ./...` all clean.